### PR TITLE
W-12347014: For consistency, the code callouts should all use [calloutlist]

### DIFF
--- a/modules/ROOT/pages/add-request-response-details.adoc
+++ b/modules/ROOT/pages/add-request-response-details.adoc
@@ -232,7 +232,9 @@ types:
           examples:
             output: !include examples/AmericanFlightExample.raml //<1>
 --
-<1> New example defined in your `examples` folder.
++
+[calloutlist]
+.. New example defined in your `examples` folder.
 
 
 == Define a Request Example
@@ -276,7 +278,8 @@ types:
           examples:
             output: !include examples/AmericanFlightExample.raml
 --
-<1> `AmericanFlight` is defined as the type for the `post` method.
+[calloutlist]
+.. `AmericanFlight` is defined as the type for the `post` method.
 . Under your `examples` folder, create a new example file named `AmericanFlightNoIDExample.raml`.
 . Add the following information to your example file:
 +
@@ -335,7 +338,9 @@ types:
           examples:
             output: !include examples/AmericanFlightExample.raml
 --
-<1> Define the example file you created earlier as an example for your `/{ID}:post` method.
++
+[calloutlist]
+.. Define the example file you created earlier as an example for your `/{ID}:post` method.
 
 Additionally, you can define the type of response of your `post` method for your `/flights` resource:
 
@@ -384,7 +389,9 @@ types:
           examples:
             output: !include examples/AmericanFlightExample.raml
 --
-<1> Create a 201 response with the required `body` > `application/json` > `example` elements.
++
+[calloutlist]
+.. Create a 201 response with the required `body` > `application/json` > `example` elements.
 . As an example, define a custom message: *Flight added (but not really)*:
 +
 [source,raml,linenums]

--- a/modules/ROOT/pages/configure-slack-integration.adoc
+++ b/modules/ROOT/pages/configure-slack-integration.adoc
@@ -67,7 +67,8 @@ image::add-slack-config.png[]
   <slack:message ><![CDATA[#["Please handle this case. " ++ payload]]]></slack:message>
 </slack:post-message>
 --
-<1> Set the `channel` field to the channel name that you set earlier in the walkthrough.
+[calloutlist]
+.. Set the `channel` field to the channel name that you set earlier in the walkthrough.
 
 == Test Your Mule Application
 

--- a/modules/ROOT/pages/connect-to-a-db.adoc
+++ b/modules/ROOT/pages/connect-to-a-db.adoc
@@ -64,7 +64,8 @@ image::add-mysql-driver-dependency.png[]
     </configuration>
 </plugin>
 --
-<1> Add a shared library configuration.
+[calloutlist]
+.. Add a shared library configuration.
 +
 image::add-shared-library.png[]
 

--- a/modules/ROOT/pages/create-config-files.adoc
+++ b/modules/ROOT/pages/create-config-files.adoc
@@ -117,7 +117,8 @@ image::add-mysql-driver-dependency.png[]
     </configuration>
 </plugin>
 --
-<1> Add a shared library configuration.
+[calloutlist]
+.. Add a shared library configuration.
 +
 image::add-shared-library.png[]
 

--- a/modules/ROOT/pages/dataweave-validations.adoc
+++ b/modules/ROOT/pages/dataweave-validations.adoc
@@ -37,8 +37,8 @@ output application/json
 ---
 toUpper("hello")
 --
-
-<1> A new function declaration for you to define your function.
+[calloutlist]
+.. A new function declaration for you to define your function.
 
 For example, you can define the function to use the `upper` function to return the provided String in uppercase characters:
 
@@ -50,8 +50,8 @@ output application/json
 ---
 toUpper("hello")
 --
-
-<1> Define your custom `toUpper` function.
+[calloutlist]
+.. Define your custom `toUpper` function.
 
 Additionally, you can preview the result of your function by locating your cursor within your DataWeave code, clicking the *Show Code Actions* icon, and selecting *Run Preview*:
 

--- a/modules/ROOT/pages/debug-add-logger-set-variables.adoc
+++ b/modules/ROOT/pages/debug-add-logger-set-variables.adoc
@@ -60,7 +60,8 @@ See xref:implement-api-specification.adoc[]
 
 </flow>
 --
-<1> Move through the attributes of the snippet and set the following values:
+[calloutlist]
+.. Move through the attributes of the snippet and set the following values:
 +
 value:: `_#[payload]_`.
 doc:name:: `_Set Database Payload_`.
@@ -113,7 +114,8 @@ variableName:: `_databasePayload_`.
 
 </flow>
 --
-<1> Move through the attributes of the snippet and set the following values:
+[calloutlist]
+.. Move through the attributes of the snippet and set the following values:
 +
 doc:name:: `_Log Payload_`.
 message:: `_#[%dw 2.0 output application/json --- payload]_`.

--- a/modules/ROOT/pages/deploy-mule-application.adoc
+++ b/modules/ROOT/pages/deploy-mule-application.adoc
@@ -54,7 +54,8 @@ image::deploy-json-file.png[]
   "autoStart": true
 }
 --
-<1> The `applicationName` property defines part of the URL that you use to access your application on Cloudhub. +
+[calloutlist]
+.. The `applicationName` property defines part of the URL that you use to access your application on Cloudhub. +
 The name must be unique across all applications deployed to Cloudhub.
 
 == Deploy the Application

--- a/modules/ROOT/pages/extract-payload-information.adoc
+++ b/modules/ROOT/pages/extract-payload-information.adoc
@@ -32,9 +32,10 @@ Before you begin, ensure you:
     </ee:variables>
   </ee:transform>
 --
-<1> `casestatus` retrieves the Salesforce case status: *New*, *Working*, or *Escalated*.
-<2> `casenumber` retrieves the case number created by Salesforce.
-<3> Set the `slackchannel` to the channel name that you set earlier in the walkthrough.
+[calloutlist]
+.. `casestatus` retrieves the Salesforce case status: *New*, *Working*, or *Escalated*.
+.. `casenumber` retrieves the case number created by Salesforce.
+.. Set the `slackchannel` to the channel name that you set earlier in the walkthrough.
 
 
 == Concatenate Your Values in The Payload

--- a/modules/ROOT/pages/mock-data-using-dw-library.adoc
+++ b/modules/ROOT/pages/mock-data-using-dw-library.adoc
@@ -120,7 +120,8 @@ image::deploy-json-file.png[]
   "autoStart": true
 }
 --
-<1> The `applicationName` property defines the part of the URL that you use to access your application on CloudHub. +
+[calloutlist]
+.. The `applicationName` property defines the part of the URL that you use to access your application on CloudHub. +
 The name must be unique across all applications deployed to CloudHub.
 . Open the Command Palette (`ctrl/cmd + shift + P`) and type _MuleSoft: Deploy to Cloudhub_.
 . Select your preferred environment.

--- a/modules/ROOT/pages/sync-api-configure-queries.adoc
+++ b/modules/ROOT/pages/sync-api-configure-queries.adoc
@@ -182,11 +182,11 @@ With the condition for whether the contact exists and the error message configur
 <logger level="INFO" message='#["Existing phone number in salesforce: " ++ vars.phonenumberSFVar]' doc:name="Logger" /> //<3>
 <set-variable variableName="ReturnMessage" value="Contact exists in Salesforce" doc:name="Set Return Message" /> //<4>
 --
-+
-<1> A Set Variable component to assign the value of the contact’s phone to a temporary variable named `phonenumberSFVar`.
-<2> A second Set Variable component to store the ID to a temporary variable named `IdVar`.
-<3> A Logger to print the value of the phone found in the record.
-<4> A Set Variable to assign a temporary value to the `ReturnMessage` variable.
+[calloutlist]
+.. A Set Variable component to assign the value of the contact’s phone to a temporary variable named `phonenumberSFVar`.
+.. A second Set Variable component to store the ID to a temporary variable named `IdVar`.
+.. A Logger to print the value of the phone found in the record.
+.. A Set Variable to assign a temporary value to the `ReturnMessage` variable.
 +
 image::final-choice-api-sync.png[]
 


### PR DESCRIPTION
This change is for consistency. Having the traditional Asciidoc code callouts such as:

```
[source,XML]
--
this line //<1>
--

<1> This line
```

Still works and won't get deprecated.