### PR TITLE
W-14087871 add test encrypted prop step open beta ga duke

### DIFF
--- a/modules/ROOT/pages/int-create-secure-configs.adoc
+++ b/modules/ROOT/pages/int-create-secure-configs.adoc
@@ -454,7 +454,7 @@ from properties provider environment properties provider
 .. Navigate to *Manage* (gear icon) > *Settings*, and find *Runtime: Default Arguments* on the *Settings* page. 
 .. In the *Runtime: Default Arguments* field, append the key-value pair for your encryption key to the _end_ of the configuration. For example:
 +
-[source,key-configuration]
+[source,env-configuration]
 ----
 -M-Dencryption.key=my-key-value
 ----

--- a/modules/ROOT/pages/int-create-secure-configs.adoc
+++ b/modules/ROOT/pages/int-create-secure-configs.adoc
@@ -464,7 +464,7 @@ In the example, `-M-D` is the required prefix, `encryption.key` is the default n
 +
 For example, for a file `dev.secure.yaml` that contains properties for the development environment within the IDE:
 +
-[source,key-configuration]
+[source,env-configuration]
 ----
 -M-Dmule.env=dev
 ----

--- a/modules/ROOT/pages/int-create-secure-configs.adoc
+++ b/modules/ROOT/pages/int-create-secure-configs.adoc
@@ -460,7 +460,7 @@ from properties provider environment properties provider
 ----
 +
 In the example, `-M-D` is the required prefix, `encryption.key` is the default name of the encryption key, and `my-key-value` is the value used to encrypt the properties through the Secure Properties Tool.
-.. If you are using a variable such as `$\{env}` in `$\{env}.secure.yaml` to identify the properties file in `<secure-properties:config/>`, append the value to the *Runtime: Default Arguments* field. 
+.. If you are using a variable such as `$\{env}` in `$\{env}.secure.yaml` to identify the properties file in `<secure-properties:config/>`, append a value for `$\{env}` to the *Runtime: Default Arguments* field. 
 +
 For example, for a file `dev.secure.yaml` that contains properties for the development environment within the IDE:
 +

--- a/modules/ROOT/pages/int-create-secure-configs.adoc
+++ b/modules/ROOT/pages/int-create-secure-configs.adoc
@@ -460,6 +460,14 @@ from properties provider environment properties provider
 ----
 +
 In the example, `-M-D` is the required prefix, `encryption.key` is the default name of the encryption key, and `my-key-value` is the value used to encrypt the properties through the Secure Properties Tool.
+.. If you are using a variable such as `$\{env}` in `$\{env}.secure.yaml` to identify the properties file in `<secure-properties:config/>`, append the value to the *Runtime: Default Arguments* field. 
++
+For example, for a file `dev.secure.yaml` that contains properties for the development environment within the IDE:
++
+[source,key-configuration]
+----
+-M-Dmule.env=dev
+----
 . Deploy the application locally within the IDE by pressing Cmd+shift+p (Mac) or Ctrl+shift+p (Windows), and entering *View: Show Run and Debug*, then clicking *Run and Debug*.
 +
 A successful deployment produces the following message in the *OUTPUT* tab of the output panel. For information about the output panel, see xref:configure-default-output-panel.adoc[].

--- a/modules/ROOT/pages/int-create-secure-configs.adoc
+++ b/modules/ROOT/pages/int-create-secure-configs.adoc
@@ -454,7 +454,7 @@ from properties provider environment properties provider
 .. Navigate to *Manage* (gear icon) > *Settings*, and find *Runtime: Default Arguments* on the *Settings* page. 
 .. In the *Runtime: Default Arguments* field, append the key-value pair for your encryption key to the _end_ of the configuration. For example:
 +
-[source,env-configuration]
+[source,key-configuration]
 ----
 -M-Dencryption.key=my-key-value
 ----


### PR DESCRIPTION
merging reviewed changes into open-beta-ga to sync with latest

added a step on testing encrypted props in the IDE when you're using a variable for the property file name in the secure config element