### PR TITLE
W-15991848 cleanup mismatched backticks

### DIFF
--- a/modules/ROOT/pages/_partials/mule-components/4.4/component-logger.adoc
+++ b/modules/ROOT/pages/_partials/mule-components/4.4/component-logger.adoc
@@ -86,7 +86,7 @@ When this field is empty, the Logger produces the following message:
 
 | *Level*
 | `level` 
-| Options are `DEBUG`, `ERROR`, `INFO` (default), `TRACE`, `WARN`. In the console, the logger message begins with the `level.
+| Options are `DEBUG`, `ERROR`, `INFO` (default), `TRACE`, `WARN`. In the console, the logger message begins with the `level`.
 
 | *Category*
 | `category` 

--- a/modules/ROOT/pages/tut-af-integrate-use-dataweave.adoc
+++ b/modules/ROOT/pages/tut-af-integrate-use-dataweave.adoc
@@ -364,7 +364,7 @@ If the MySQL test server is not available, this error occurs:
 [[source,error]]
 ----
 Cannot get connection for URL jdbc:mysql://mudb.learn.mulesoft.com:3306/ : 
-Communications link failure"`. 
+Communications link failure". 
 ----
 +
 To address the issue, try again until you get a successful response.

--- a/modules/ROOT/pages/tut-af-integrate-use-dataweave.adoc
+++ b/modules/ROOT/pages/tut-af-integrate-use-dataweave.adoc
@@ -364,7 +364,7 @@ If the MySQL test server is not available, this error occurs:
 [[source,error]]
 ----
 Cannot get connection for URL jdbc:mysql://mudb.learn.mulesoft.com:3306/ : 
-Communications link failure". 
+Communications link failure. 
 ----
 +
 To address the issue, try again until you get a successful response.


### PR DESCRIPTION
I ran a script to find mismatched backticks in the API Manager docs (after noticing one) and just ran it on the few repositories I had pulled down locally, too.

I found and fixed two docs in docs-code-builder