### PR TITLE
Update filterExpression description for clarity

### DIFF
--- a/modules/ROOT/pages/_partials/mule-components/4.4/component-cache.adoc
+++ b/modules/ROOT/pages/_partials/mule-components/4.4/component-cache.adoc
@@ -168,7 +168,7 @@ Cache (`<cache/>`) attributes are configurable through the UI and XML:
 
 | *Filter expression*
 | `filterExpression`
-| DataWeave expression for excluding specific payloads from the Cache scope flow.
+| DataWeave expression for excluding specific payloads from caching. If the expression evaluates to false, the payload will not be cached.
 
 |===
 


### PR DESCRIPTION
Clarified the description of the filterExpression attribute to specify that payloads will not be cached if the expression evaluates to false.