### PR TITLE
W-23365932: Add Australia Cloud to Code Builder cloud hosts

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -27,7 +27,7 @@ Get the Anypoint Code Builder experience through the Anypoint Extension Pack for
 [[us-eu-clouds]]
 == Cloud Hosts
 
-Anypoint Code Builder is available through Anypoint Platform from US, EU, Canada (desktop IDE only), Japan (desktop IDE only), and India (desktop IDE only) cloud hosts. To help your organization meet emerging regulatory requirements that differ by region, Anypoint Platform does not share organization information, permissions, account data, or projects between hosts.
+Anypoint Code Builder is available through Anypoint Platform from US, EU, Canada (desktop IDE only), Japan (desktop IDE only), India (desktop IDE only), and Australia (desktop IDE only) cloud hosts. To help your organization meet emerging regulatory requirements that differ by region, Anypoint Platform does not share organization information, permissions, account data, or projects between hosts.
 
 [%header,cols="1,1,2"]
 |===
@@ -52,6 +52,10 @@ Anypoint Code Builder is available through Anypoint Platform from US, EU, Canada
 |India Cloud (desktop IDE only)
 |https://in1.platform.mulesoft.com/login/[in1.platform.mulesoft.com^]
 |MuleSoft hosts this control plane within India (APAC) data centers.
+
+|Australia Cloud (desktop IDE only)
+|https://au1.platform.mulesoft.com/login/[au1.platform.mulesoft.com^]
+|MuleSoft hosts this control plane within Australia (APAC) data centers.
 |===
 
 Anypoint Platform hosts deployment targets for managed Mule runtime versions and related data, including data and metadata about your Mule implementations.


### PR DESCRIPTION
## Summary

Replicates India Cloud change from PR #632 for Australia Cloud.

- **`index.adoc`**: Updated introductory sentence to include Australia (desktop IDE only) in the list of available cloud hosts.
- **`index.adoc`**: Added Australia Cloud row to the Cloud Hosts table with platform URL `https://au1.platform.mulesoft.com/login/`.