### PR TITLE
W-23515994 Rename Flex Gateway to Omni Gateway in customer-facing text

### DIFF
--- a/agent-network/2.0/modules/ROOT/pages/af-agent-network-yaml-reference.adoc
+++ b/agent-network/2.0/modules/ROOT/pages/af-agent-network-yaml-reference.adoc
@@ -1037,9 +1037,9 @@ You can attach policies to connection objects by referencing their policy identi
 
 This section describes reusable, composable policy bindings and definitions that govern specific behaviors or constraints related to connections. You must reference the policy identifier to attach a policy. 
 
-For more information about applying policies via Flex Gateway in Local Mode, see:
+For more information about applying policies via Omni Gateway in Local Mode, see:
 
-* https://docs.mulesoft.com/gateway/latest/flex-agent-secure[Securing Agent Interactions with Flex Gateway]
+* https://docs.mulesoft.com/gateway/latest/flex-agent-secure[Securing Agent Interactions with Omni Gateway]
 * https://docs.mulesoft.com/gateway/latest/flex-gateway-secure-local[Applying Policies in Local Mode]
 
 *Example*


### PR DESCRIPTION
## Summary
Renames customer-facing mentions of "Flex Gateway" to "Omni Gateway" in Agent Network documentation.

## Changes
- Updated policy documentation references from "Flex Gateway" to "Omni Gateway"
- Modified link text in af-agent-network-yaml-reference.adoc

## Test plan
- [ ] Review changes to ensure all customer-facing text has been updated
- [ ] Verify documentation builds successfully
- [ ] Confirm no broken links or references

🤖 Generated with [Claude Code](https://claude.com/claude-code)