### PR TITLE
W-23612601 Rename LLM Proxy to Model Proxy

### DIFF
--- a/agent-network/1.0/modules/ROOT/pages/af-agent-networks.adoc
+++ b/agent-network/1.0/modules/ROOT/pages/af-agent-networks.adoc
@@ -131,7 +131,7 @@ NOTE: In a shared space, or in a private space using a single-gateway configurat
 [[llm-support]]
 == Large Language Models
 
-Agent network brokers support the latest Gemini and OpenAI models and LLM Proxies.
+Agent network brokers support the latest Gemini and OpenAI models and Model Proxies.
 
 * Azure OpenAI and OpenAI API:
 +
@@ -152,9 +152,9 @@ For more information about these models, see the https://developers.openai.com/a
 +
 For more information about these models, see the https://ai.google.dev/gemini-api/docs/models[Gemini] documentation.
 
-* LLM Proxy:
+* Model Proxy:
 +
-LLM Proxy provides a unified endpoint for multiple LLM providers including Gemini, OpenAI, Bedrock (Anthropic Claude models), and NVIDIA Nemotron. To find the supported models, see xref:gateway::flex-gateway-llm-proxy.adoc#supported-llm-providers[LLM Proxy Supported LLM Providers].
+Model Proxy provides a unified endpoint for multiple LLM providers including Gemini, OpenAI, Bedrock (Anthropic Claude models), and NVIDIA Nemotron. To find the supported models, see xref:general::model-proxy.adoc#supported-llm-providers[Model Proxy Supported LLM Providers].
 
 This table details the requirements and recommended models.
 

--- a/agent-network/1.0/modules/ROOT/pages/af-project-files.adoc
+++ b/agent-network/1.0/modules/ROOT/pages/af-project-files.adoc
@@ -230,7 +230,7 @@ The `spec` element has these properties.
 
 `llm`
 
-The value of this section is a reference to one of the LLMs defined in Anypoint Exchange or in the `llmProviders` section of `agent-network.yaml`. Because it's a reference, you can choose to share the same LLM across all the brokers in your agent network. Or, you can have different brokers use different LLMs to better suit their tasks. If using an LLM Proxy, configure the LLM Proxy as either an OpenAI or Gemini LLM depending on the proxy's format.
+The value of this section is a reference to one of the LLMs defined in Anypoint Exchange or in the `llmProviders` section of `agent-network.yaml`. Because it's a reference, you can choose to share the same LLM across all the brokers in your agent network. Or, you can have different brokers use different LLMs to better suit their tasks. If using a Model Proxy, configure the Model Proxy as either an OpenAI or Gemini LLM depending on the proxy's format.
 
 For more information about supported LLMs, see xref:af-agent-networks.adoc#llm-support[Large Language Models].
 
@@ -745,7 +745,7 @@ connections:
     spec:
       url: https://api.openai.com/v1/
       configuration:
-        apiKey: ${openai.apiKey} # Define the API key of an LLM Proxy as <<clientId>>:<<clientSecret>>
+        apiKey: ${openai.apiKey} # Define the API key of a Model Proxy as <<clientId>>:<<clientSecret>>
 
   talent-pool-mcp:
     kind: mcp

--- a/agent-network/2.0/modules/ROOT/pages/af-agent-networks.adoc
+++ b/agent-network/2.0/modules/ROOT/pages/af-agent-networks.adoc
@@ -142,7 +142,7 @@ Applications or APIs exposed through the Model Context Protocol (MCP). MCP is an
 [[llm-support]]
 == Large Language Models
 
-Agent network brokers support the latest models from OpenAI, Azure OpenAI, Bedrock OpenAI, and Gemini, as well as LLM Proxies.
+Agent network brokers support the latest models from OpenAI, Azure OpenAI, Bedrock OpenAI, and Gemini, as well as Model Proxies.
 
 * https://developers.openai.com/api/docs/models[OpenAI]
 * https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models[Azure OpenAI]
@@ -151,9 +151,9 @@ Agent network brokers support the latest models from OpenAI, Azure OpenAI, Bedro
 NOTE: Bedrock OpenAI uses the `openai.` prefix for model names (for example, `openai.gpt-5.5`), which differs from the model names used with OpenAI and Azure OpenAI.
 * https://ai.google.dev/gemini-api/docs/models[Gemini]
 
-* LLM Proxy
+* Model Proxy
 +
-Agent network brokers only support access to OpenAI and Gemini through xref:gateway::flex-gateway-llm-proxy.adoc[Omni Gateway LLM Proxy]. Transcoding other models to OpenAI format to use in agent networks is not supported.
+Agent network brokers only support access to OpenAI and Gemini through xref:general::model-proxy.adoc[Omni Gateway Model Proxy]. Transcoding other models to OpenAI format to use in agent networks is not supported.
 
 This table details requirements and recommended models.
 


### PR DESCRIPTION
## Summary

Rename "LLM Proxy" to "Model Proxy" across Agent Network documentation.

### Content replacements (case-preserving)
- `LLM Proxy`/`LLM Proxies` → `Model Proxy`/`Model Proxies` in:
  - `agent-network/1.0/modules/ROOT/pages/af-agent-networks.adoc`
  - `agent-network/1.0/modules/ROOT/pages/af-project-files.adoc`
  - `agent-network/2.0/modules/ROOT/pages/af-agent-networks.adoc`
- Fixed article grammar (`an Model Proxy` → `a Model Proxy`).

### Reference updates
- Cross-repo xrefs updated for the page move from the `gateway` to the `general` component:
  - `xref:gateway::flex-gateway-llm-proxy.adoc` → `xref:general::model-proxy.adoc` (anchors preserved, e.g. `#supported-llm-providers`).

### Not changed
- No `x-llm-proxy-*` HTTP headers present in these files.
- No file renames required (no llm-proxy filenames in this repo).