### PR TITLE
W-23748914: Add United Kingdom Cloud to Anypoint Code Builder cloud hosts

### DIFF
--- a/code-builder-home/modules/ROOT/pages/index.adoc
+++ b/code-builder-home/modules/ROOT/pages/index.adoc
@@ -27,7 +27,7 @@ Get the Anypoint Code Builder experience through the Anypoint Extension Pack for
 [[us-eu-clouds]]
 == Cloud Hosts
 
-Anypoint Code Builder is available through Anypoint Platform from US, EU, Canada (desktop IDE only), Japan (desktop IDE only), India (desktop IDE only), and Australia (desktop IDE only) cloud hosts. To help your organization meet emerging regulatory requirements that differ by region, Anypoint Platform does not share organization information, permissions, account data, or projects between hosts.
+Anypoint Code Builder is available through Anypoint Platform from US, EU, Canada (desktop IDE only), Japan (desktop IDE only), India (desktop IDE only), Australia (desktop IDE only), and United Kingdom (desktop IDE only) cloud hosts. To help your organization meet emerging regulatory requirements that differ by region, Anypoint Platform does not share organization information, permissions, account data, or projects between hosts.
 
 [%header,cols="1,1,2"]
 |===
@@ -56,6 +56,10 @@ Anypoint Code Builder is available through Anypoint Platform from US, EU, Canada
 |Australia Cloud (desktop IDE only)
 |https://au1.platform.mulesoft.com/login/[au1.platform.mulesoft.com^]
 |MuleSoft hosts this control plane within Australia (APAC) data centers.
+
+|United Kingdom Cloud (desktop IDE only)
+|https://gb1.platform.mulesoft.com/login/[gb1.platform.mulesoft.com^]
+|MuleSoft hosts this control plane within United Kingdom (Europe) data centers.
 |===
 
 Anypoint Platform hosts deployment targets for managed Mule runtime versions and related data, including data and metadata about your Mule implementations.


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud change from PR #709 for United Kingdom Cloud.

- **`code-builder-home/.../index.adoc`**: Added United Kingdom (desktop IDE only) to the Cloud Hosts intro sentence and a United Kingdom Cloud row (`gb1.platform.mulesoft.com/login/`, hosted within United Kingdom (Europe) data centers).

Made with [Cursor](https://cursor.com)